### PR TITLE
chore: switch backend default port to 8080

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -89,7 +89,7 @@ DEEPSEEK_API_KEY=sk-...    # Your DeepSeek API key
 
 # API Configuration
 API_HOST=0.0.0.0
-API_PORT=8000
+API_PORT=8080
 CORS_ORIGINS=http://localhost:3000
 ```
 
@@ -138,7 +138,7 @@ You should see:
 
 ```
 🚀 Starting ROMA Trading Platform
-API Server: http://0.0.0.0:8000
+API Server: http://0.0.0.0:8080
 Initialized TradingAgent: deepseek_aggressive
 All agents started successfully
 ```
@@ -157,7 +157,7 @@ cd /path/to/roma-01/frontend
 npm install
 
 # Create environment file
-echo "NEXT_PUBLIC_API_URL=http://localhost:8000" > .env.local
+echo "NEXT_PUBLIC_API_URL=http://localhost:8080" > .env.local
 
 # Start development server
 npm run dev
@@ -183,7 +183,7 @@ You should see:
 
 ## ✅ Verification Checklist
 
-- [ ] Backend is running on port 8000
+- [ ] Backend is running on port 8080
 - [ ] Frontend is running on port 3000
 - [ ] Can access http://localhost:3000
 - [ ] See agent cards with "Running" status
@@ -257,8 +257,8 @@ pip install -e .
 
 **Backend won't start:**
 ```bash
-# Check if port 8000 is already in use
-lsof -i :8000
+# Check if port 8080 is already in use
+lsof -i :8080
 
 # If yes, kill the process or change port in .env
 ```
@@ -266,7 +266,7 @@ lsof -i :8000
 **Frontend can't connect:**
 ```bash
 # Verify backend is running
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 
 # Should return: {"status":"healthy"}
 ```

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ npm run dev
 ### Access
 
 - **Frontend**: http://localhost:3000
-- **Backend API**: http://localhost:8000
-- **API Docs**: http://localhost:8000/docs
+- **Backend API**: http://localhost:8080
+- **API Docs**: http://localhost:8080/docs
 
 📖 **Full guide**: See [QUICKSTART.md](QUICKSTART.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,8 +128,8 @@ npm run dev
 ### 访问
 
 - **前端**：http://localhost:3000
-- **后端 API**：http://localhost:8000
-- **API 文档**：http://localhost:8000/docs
+- **后端 API**：http://localhost:8080
+- **API 文档**：http://localhost:8080/docs
 
 📖 **完整指南**：查看 [QUICKSTART.md](QUICKSTART.md)
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,7 +42,7 @@ COPY config/ ./config/
 RUN mkdir -p logs
 
 # Expose port
-EXPOSE 8000
+EXPOSE 8080
 
 # Run the application
 CMD ["python", "-m", "roma_trading.main"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,7 +21,7 @@ cd config
 ./start.sh
 ```
 
-Server runs on `http://localhost:8000`
+Server runs on `http://localhost:8080`
 
 ## Architecture
 
@@ -90,7 +90,7 @@ This allows flexible combinations: any account can pair with any model, and mult
 ### WebSocket
 - `WS /ws/agents/{id}` - Real-time agent updates
 
-Full API docs: http://localhost:8000/docs
+Full API docs: http://localhost:8080/docs
 
 ## Configuration
 

--- a/backend/config/README.md
+++ b/backend/config/README.md
@@ -53,7 +53,7 @@ This file controls system-wide settings that apply to all trading agents.
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `api.host` | String | API server host address | 0.0.0.0 |
-| `api.port` | Integer | API server port | 8000 |
+| `api.port` | Integer | API server port | 8080 |
 
 ### Agent Configuration
 

--- a/backend/config/trading_config.yaml
+++ b/backend/config/trading_config.yaml
@@ -16,7 +16,7 @@ system:
 
 api:
   host: "0.0.0.0"
-  port: 8000
+  port: 8080
 
 # ============================================
 # Accounts: Define your DEX trading accounts

--- a/backend/config/trading_config.yaml.example
+++ b/backend/config/trading_config.yaml.example
@@ -16,7 +16,7 @@ system:
 
 api:
   host: "0.0.0.0"
-  port: 8000
+  port: 8080
 
 # ============================================
 # Accounts: Define your DEX trading accounts

--- a/backend/src/roma_trading/config/settings.py
+++ b/backend/src/roma_trading/config/settings.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
 
     # API Configuration
     api_host: str = "0.0.0.0"
-    api_port: int = 8000
+    api_port: int = 8080
     cors_origins: str = "http://localhost:3000"
 
     @property

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8080:8080"
     env_file:
       - .env
     environment:
       # API Config (override if needed)
       - API_HOST=0.0.0.0
-      - API_PORT=8000
+      - API_PORT=8080
       - CORS_ORIGINS=*
     volumes:
       - ./backend/config:/app/config
@@ -20,7 +20,7 @@ services:
       - backend-data:/app/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -33,7 +33,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8080
     depends_on:
       - backend
     restart: unless-stopped

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -91,9 +91,9 @@ docker-compose logs -f frontend
 访问服务：
 
 - **前端界面**: http://localhost:3000
-- **后端 API**: http://localhost:8000
-- **API 文档**: http://localhost:8000/docs
-- **健康检查**: http://localhost:8000/health
+- **后端 API**: http://localhost:8080
+- **API 文档**: http://localhost:8080/docs
+- **健康检查**: http://localhost:8080/health
 
 #### 4. 验证交易智能体
 
@@ -108,7 +108,7 @@ docker-compose logs -f frontend
 - 通过 API 确认：
 
   ```bash
-  curl http://localhost:8000/api/agents
+  curl http://localhost:8080/api/agents
   ```
 
 如需调整智能体配置，修改 `backend/config/trading_config.yaml` 后重启后端服务即可生效。
@@ -170,7 +170,7 @@ docker build -t roma-01-backend .
 # 运行容器
 docker run -d \
   --name roma-backend \
-  -p 8000:8000 \
+  -p 8080:8080 \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --env-file ../.env \
@@ -238,7 +238,7 @@ server {
     server_name api.yourdomain.com;
 
     location / {
-        proxy_pass http://localhost:8000;
+        proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -301,7 +301,7 @@ docker-compose config
 
 #### API 连接失败
 
-1. 检查端口是否被占用：`lsof -i :8000`
+1. 检查端口是否被占用：`lsof -i :8080`
 2. 检查防火墙设置
 3. 验证环境变量是否正确加载
 
@@ -422,9 +422,9 @@ docker-compose logs -f frontend
 Access services:
 
 - **Frontend UI**: http://localhost:3000
-- **Backend API**: http://localhost:8000
-- **API Docs**: http://localhost:8000/docs
-- **Health Check**: http://localhost:8000/health
+- **Backend API**: http://localhost:8080
+- **API Docs**: http://localhost:8080/docs
+- **Health Check**: http://localhost:8080/health
 
 #### 4. Verify Trading Agents
 
@@ -439,7 +439,7 @@ The backend container automatically loads and starts every trading agent defined
 - Query the API:
 
   ```bash
-  curl http://localhost:8000/api/agents
+  curl http://localhost:8080/api/agents
   ```
 
 To change agent behavior, update `backend/config/trading_config.yaml` and restart the backend service.
@@ -501,7 +501,7 @@ docker build -t roma-01-backend .
 # Run container
 docker run -d \
   --name roma-backend \
-  -p 8000:8000 \
+  -p 8080:8080 \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --env-file ../.env \
@@ -569,7 +569,7 @@ server {
     server_name api.yourdomain.com;
 
     location / {
-        proxy_pass http://localhost:8000;
+        proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -632,7 +632,7 @@ docker-compose config
 
 #### API Connection Failed
 
-1. Check if port is already in use: `lsof -i :8000`
+1. Check if port is already in use: `lsof -i :8080`
 2. Check firewall settings
 3. Verify environment variables are loaded correctly
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -219,8 +219,8 @@ cd frontend && npm run dev
 
 ### Access
 - Dashboard: http://localhost:3000
-- API: http://localhost:8000
-- Docs: http://localhost:8000/docs
+- API: http://localhost:8080
+- Docs: http://localhost:8080/docs
 
 ### Monitor
 ```bash

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -21,10 +21,10 @@ Practical examples of using the ROMA-01 API in different programming languages.
 import requests
 import json
 
-BASE_URL = "http://localhost:8000"
+BASE_URL = "http://localhost:8080"
 
 class RomaClient:
-    def __init__(self, base_url: str = "http://localhost:8000"):
+    def __init__(self, base_url: str = "http://localhost:8080"):
         self.base_url = base_url
     
     def get(self, endpoint: str):
@@ -88,7 +88,7 @@ import websockets
 import json
 
 async def stream_agent_updates(agent_id: str):
-    uri = f"ws://localhost:8000/ws/agents/{agent_id}"
+    uri = f"ws://localhost:8080/ws/agents/{agent_id}"
     
     async with websockets.connect(uri) as websocket:
         print(f"✅ Connected to {agent_id}\n")
@@ -125,7 +125,7 @@ asyncio.run(stream_agent_updates("deepseek-chat-v3.1"))
 ### Fetch API (REST)
 
 ```typescript
-const BASE_URL = "http://localhost:8000";
+const BASE_URL = "http://localhost:8080";
 
 interface Agent {
   id: string;
@@ -180,7 +180,7 @@ class AgentMonitor {
   }
   
   private connect() {
-    this.ws = new WebSocket(`ws://localhost:8000/ws/agents/${this.agentId}`);
+    this.ws = new WebSocket(`ws://localhost:8080/ws/agents/${this.agentId}`);
     
     this.ws.onopen = () => {
       console.log('✅ Connected');
@@ -261,7 +261,7 @@ export function useAgentWebSocket(agentId: string, options: UseWebSocketOptions 
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
   
   useEffect(() => {
-    const ws = new WebSocket(`ws://localhost:8000/ws/agents/${agentId}`);
+    const ws = new WebSocket(`ws://localhost:8080/ws/agents/${agentId}`);
     
     ws.onopen = () => {
       setIsConnected(true);
@@ -310,27 +310,27 @@ function AgentDashboard({ agentId }: { agentId: string }) {
 
 ### Get Agents
 ```bash
-curl http://localhost:8000/api/agents
+curl http://localhost:8080/api/agents
 ```
 
 ### Get Agent Account
 ```bash
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/account
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/account
 ```
 
 ### Get Positions (Pretty Print)
 ```bash
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/positions | jq '.'
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/positions | jq '.'
 ```
 
 ### Get Market Prices
 ```bash
-curl "http://localhost:8000/api/market/prices?symbols=BTCUSDT,ETHUSDT"
+curl "http://localhost:8080/api/market/prices?symbols=BTCUSDT,ETHUSDT"
 ```
 
 ### Get Recent Decisions
 ```bash
-curl "http://localhost:8000/api/agents/deepseek-chat-v3.1/decisions?limit=5" | jq '.[] | {cycle, decisions}'
+curl "http://localhost:8080/api/agents/deepseek-chat-v3.1/decisions?limit=5" | jq '.[] | {cycle, decisions}'
 ```
 
 ### WebSocket (with wscat)
@@ -339,7 +339,7 @@ curl "http://localhost:8000/api/agents/deepseek-chat-v3.1/decisions?limit=5" | j
 npm install -g wscat
 
 # Connect to WebSocket
-wscat -c ws://localhost:8000/ws/agents/deepseek-chat-v3.1
+wscat -c ws://localhost:8080/ws/agents/deepseek-chat-v3.1
 ```
 
 ---
@@ -376,7 +376,7 @@ export function CustomDashboard() {
 
 ```python
 async def trade_alerter(agent_id: str, min_value_usd: float = 100):
-    uri = f"ws://localhost:8000/ws/agents/{agent_id}"
+    uri = f"ws://localhost:8080/ws/agents/{agent_id}"
     
     async with websockets.connect(uri) as ws:
         async for message in ws:
@@ -477,7 +477,7 @@ async def compare_agents():
 ### Using Fetch API
 
 ```javascript
-const BASE_URL = "http://localhost:8000";
+const BASE_URL = "http://localhost:8080";
 
 // Get agents with error handling
 async function getAgents() {
@@ -544,7 +544,7 @@ export function AgentCard({ agentId }: { agentId: string }) {
 class RomaWebSocket {
   constructor(agentId) {
     this.agentId = agentId;
-    this.url = `ws://localhost:8000/ws/agents/${agentId}`;
+    this.url = `ws://localhost:8080/ws/agents/${agentId}`;
     this.reconnectDelay = 5000;
     this.maxReconnectAttempts = 10;
     this.reconnectCount = 0;
@@ -622,49 +622,49 @@ monitor
 
 ```bash
 # Get API info
-curl http://localhost:8000/
+curl http://localhost:8080/
 
 # Health check
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 
 # List agents
-curl http://localhost:8000/api/agents | jq '.'
+curl http://localhost:8080/api/agents | jq '.'
 
 # Get specific agent
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1 | jq '.'
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1 | jq '.'
 ```
 
 ### Account & Positions
 
 ```bash
 # Get account balance
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/account | jq '.total_balance'
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/account | jq '.total_balance'
 
 # Get positions
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/positions | jq '.[] | {symbol, side, pnl: .unrealized_profit}'
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/positions | jq '.[] | {symbol, side, pnl: .unrealized_profit}'
 
 # Get performance
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/performance | jq '{win_rate, total_pnl, sharpe_ratio}'
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/performance | jq '{win_rate, total_pnl, sharpe_ratio}'
 ```
 
 ### Decisions & Trades
 
 ```bash
 # Get recent decisions (last 5)
-curl "http://localhost:8000/api/agents/deepseek-chat-v3.1/decisions?limit=5" | jq '.[] | {cycle, action: .decisions[0].action}'
+curl "http://localhost:8080/api/agents/deepseek-chat-v3.1/decisions?limit=5" | jq '.[] | {cycle, action: .decisions[0].action}'
 
 # Get trade history
-curl "http://localhost:8000/api/agents/deepseek-chat-v3.1/trades?limit=10" | jq '.[] | {symbol, side, pnl: .realized_pnl}'
+curl "http://localhost:8080/api/agents/deepseek-chat-v3.1/trades?limit=10" | jq '.[] | {symbol, side, pnl: .realized_pnl}'
 ```
 
 ### Market Data
 
 ```bash
 # Get all default prices
-curl http://localhost:8000/api/market/prices | jq '.[] | {symbol, price}'
+curl http://localhost:8080/api/market/prices | jq '.[] | {symbol, price}'
 
 # Get specific symbols
-curl "http://localhost:8000/api/market/prices?symbols=BTCUSDT,ETHUSDT" | jq '.'
+curl "http://localhost:8080/api/market/prices?symbols=BTCUSDT,ETHUSDT" | jq '.'
 ```
 
 ### Monitoring Script
@@ -674,7 +674,7 @@ curl "http://localhost:8000/api/market/prices?symbols=BTCUSDT,ETHUSDT" | jq '.'
 # monitor-agent.sh - Quick agent monitoring
 
 AGENT_ID="deepseek-chat-v3.1"
-BASE_URL="http://localhost:8000"
+BASE_URL="http://localhost:8080"
 
 echo "📊 ROMA-01 Agent Monitor"
 echo "Agent: $AGENT_ID"
@@ -718,7 +718,7 @@ setInterval(async () => {
 - Building real-time dashboard
 
 ```javascript
-const ws = new WebSocket('ws://localhost:8000/ws/agents/deepseek-chat-v3.1');
+const ws = new WebSocket('ws://localhost:8080/ws/agents/deepseek-chat-v3.1');
 ws.onmessage = (event) => {
   updateUI(JSON.parse(event.data));
 };

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -6,7 +6,7 @@ Complete reference for ROMA-01 REST API endpoints.
 
 ## 📋 Base Information
 
-**Base URL**: `http://localhost:8000`  
+**Base URL**: `http://localhost:8080`  
 **Version**: 1.1.0  
 **Authentication**: None (add in production)
 
@@ -66,7 +66,7 @@ Get list of all trading agents.
 
 **cURL Example**:
 ```bash
-curl http://localhost:8000/api/agents
+curl http://localhost:8080/api/agents
 ```
 
 ---
@@ -138,7 +138,7 @@ Get current open positions for an agent.
     "symbol": "BTCUSDT",
     "side": "long",
     "position_amt": 0.001,
-    "entry_price": 68000.0,
+    "entry_price": 68080.0,
     "mark_price": 68500.0,
     "unrealized_profit": 0.50,
     "pnl_percentage": 0.74,
@@ -284,11 +284,11 @@ Get trade history.
     "symbol": "BTCUSDT",
     "side": "BUY",
     "position_side": "LONG",
-    "price": 68000.0,
+    "price": 68080.0,
     "quantity": 0.001,
     "realized_pnl": 2.50,
     "commission": 0.05,
-    "time": 1699012800000
+    "time": 1699012808000
   }
 ]
 ```
@@ -379,8 +379,8 @@ Get current market prices for trading pairs.
 
 When the backend is running, visit:
 
-**Swagger UI**: http://localhost:8000/docs  
-**ReDoc**: http://localhost:8000/redoc
+**Swagger UI**: http://localhost:8080/docs  
+**ReDoc**: http://localhost:8080/redoc
 
 These provide:
 - Interactive API testing

--- a/docs/api/websocket.md
+++ b/docs/api/websocket.md
@@ -21,7 +21,7 @@ WebSocket endpoints provide real-time streaming updates for:
 
 Connect to a specific agent for real-time updates.
 
-**Endpoint**: `ws://localhost:8000/ws/agents/{agent_id}`
+**Endpoint**: `ws://localhost:8080/ws/agents/{agent_id}`
 
 **Path Parameters**:
 - `agent_id`: Agent identifier (e.g., "deepseek-chat-v3.1")
@@ -67,7 +67,7 @@ Sent when positions change.
       "symbol": "BTCUSDT",
       "side": "long",
       "position_amt": 0.001,
-      "entry_price": 68000.0,
+      "entry_price": 68080.0,
       "mark_price": 68500.0,
       "unrealized_profit": 0.50,
       "pnl_percentage": 0.74,
@@ -171,7 +171,7 @@ Sent when agent status changes.
 
 ```typescript
 // Connect to WebSocket
-const ws = new WebSocket('ws://localhost:8000/ws/agents/deepseek-chat-v3.1');
+const ws = new WebSocket('ws://localhost:8080/ws/agents/deepseek-chat-v3.1');
 
 // Handle connection open
 ws.onopen = () => {
@@ -222,7 +222,7 @@ ws.onclose = (event) => {
 
 // Reconnection function
 function reconnect() {
-  const newWs = new WebSocket('ws://localhost:8000/ws/agents/deepseek-chat-v3.1');
+  const newWs = new WebSocket('ws://localhost:8080/ws/agents/deepseek-chat-v3.1');
   // ... setup handlers again
 }
 ```
@@ -235,7 +235,7 @@ import websockets
 import json
 
 async def connect_to_agent(agent_id: str):
-    uri = f"ws://localhost:8000/ws/agents/{agent_id}"
+    uri = f"ws://localhost:8080/ws/agents/{agent_id}"
     
     async with websockets.connect(uri) as websocket:
         print(f"✅ Connected to {agent_id}")
@@ -334,10 +334,10 @@ window.addEventListener('beforeunload', () => {
 ## 🐛 Troubleshooting
 
 ### Connection Refused
-**Error**: `WebSocket connection to 'ws://localhost:8000/...' failed`
+**Error**: `WebSocket connection to 'ws://localhost:8080/...' failed`
 
 **Solutions**:
-- Verify backend is running on port 8000
+- Verify backend is running on port 8080
 - Check firewall settings
 - Ensure WebSocket upgrade is supported
 
@@ -374,7 +374,7 @@ window.addEventListener('beforeunload', () => {
 **1. Use WSS (Secure WebSocket)**
 ```javascript
 // Development
-ws://localhost:8000/ws/...
+ws://localhost:8080/ws/...
 
 // Production
 wss://your-domain.com/ws/...

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -867,7 +867,7 @@ system:
 
 api:
   host: "0.0.0.0"
-  port: 8000
+  port: 8080
 
 agents:
   - id: "deepseek-chat-v3.1"
@@ -1022,7 +1022,7 @@ interface PerformanceMetrics {
 
 ### 4.1 REST API Endpoints
 
-**Base URL**: `http://localhost:8000`
+**Base URL**: `http://localhost:8080`
 
 #### System
 ```
@@ -1068,7 +1068,7 @@ GET  /api/market/prices?symbols=BTCUSDT,ETHUSDT  - Get current prices
 
 ### 4.2 WebSocket API
 
-**Endpoint**: `ws://localhost:8000/ws/agents/{id}`
+**Endpoint**: `ws://localhost:8080/ws/agents/{id}`
 
 **Message Types**:
 
@@ -1371,7 +1371,7 @@ services:
   backend:
     build: ./backend
     ports:
-      - "8000:8000"
+      - "8080:8080"
     env_file:
       - ./backend/.env
     volumes:
@@ -1384,7 +1384,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8080
     depends_on:
       - backend
     restart: unless-stopped
@@ -1410,7 +1410,7 @@ docker-compose up -d --build
 **Reverse Proxy** (Nginx):
 ```nginx
 upstream backend {
-    server localhost:8000;
+    server localhost:8080;
 }
 
 upstream frontend {
@@ -1511,13 +1511,13 @@ LOG_LEVEL=DEBUG python -m roma_trading.main
 
 **Health Check Endpoint**:
 ```bash
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 # Response: {"status": "healthy"}
 ```
 
 **Agent Status**:
 ```bash
-curl http://localhost:8000/api/agents
+curl http://localhost:8080/api/agents
 # Returns: List of agents with status
 ```
 
@@ -1580,13 +1580,13 @@ pytest tests/
 **Manual Testing**:
 ```bash
 # Test API
-curl http://localhost:8000/api/agents
+curl http://localhost:8080/api/agents
 
 # Test specific agent
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/account
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/account
 
 # Test WebSocket
-wscat -c ws://localhost:8000/ws/agents/deepseek-chat-v3.1
+wscat -c ws://localhost:8080/ws/agents/deepseek-chat-v3.1
 ```
 
 ### 9.3 Code Style

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -115,7 +115,7 @@ cd frontend
 npm install
 
 # 2. Configure (if needed)
-# Edit .env.local if backend not on localhost:8000
+# Edit .env.local if backend not on localhost:8080
 
 # 3. Development mode
 npm run dev
@@ -128,8 +128,8 @@ npm start
 ### Access
 
 - **Frontend**: http://localhost:3000
-- **Backend API**: http://localhost:8000
-- **API Docs**: http://localhost:8000/docs
+- **Backend API**: http://localhost:8080
+- **API Docs**: http://localhost:8080/docs
 
 ---
 
@@ -163,7 +163,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8080:8080"
     env_file:
       - ./backend/.env
     volumes:
@@ -178,7 +178,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8080
     depends_on:
       - backend
     restart: unless-stopped
@@ -191,7 +191,7 @@ services:
 cd backend
 docker build -t roma-trading-backend .
 docker run -d \
-  -p 8000:8000 \
+  -p 8080:8080 \
   --env-file .env \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
@@ -203,7 +203,7 @@ cd frontend
 docker build -t roma-trading-frontend .
 docker run -d \
   -p 3000:3000 \
-  -e NEXT_PUBLIC_API_URL=http://localhost:8000 \
+  -e NEXT_PUBLIC_API_URL=http://localhost:8080 \
   --name roma-frontend \
   roma-trading-frontend
 ```
@@ -221,7 +221,7 @@ docker run -d \
 # - Ubuntu 22.04 LTS
 # - t3.medium or larger
 # - 20GB EBS storage
-# - Security group: ports 22, 80, 443, 8000, 3000
+# - Security group: ports 22, 80, 443, 8080, 3000
 
 # 2. Connect to instance
 ssh ubuntu@<instance-ip>
@@ -253,7 +253,7 @@ cd ../frontend && npm install
       "image": "your-registry/roma-trading-backend:latest",
       "portMappings": [
         {
-          "containerPort": 8000,
+          "containerPort": 8080,
           "protocol": "tcp"
         }
       ],
@@ -441,10 +441,10 @@ ps aux | grep roma_trading
 tail -100 backend/logs/roma_trading_*.log
 
 # Verify agents running
-curl http://localhost:8000/agents | jq '.[] | {id, is_running}'
+curl http://localhost:8080/agents | jq '.[] | {id, is_running}'
 
 # Check P/L
-curl http://localhost:8000/agent/deepseek_aggressive/performance | jq .
+curl http://localhost:8080/agent/deepseek_aggressive/performance | jq .
 ```
 
 ### Weekly Tasks
@@ -517,7 +517,7 @@ sudo ufw enable
 
 # For development, also allow:
 sudo ufw allow 3000/tcp  # Frontend
-sudo ufw allow 8000/tcp  # Backend API
+sudo ufw allow 8080/tcp  # Backend API
 ```
 
 ### SSL/TLS Setup (Nginx)
@@ -544,7 +544,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://localhost:8000/;
+        proxy_pass http://localhost:8080/;
     }
 }
 
@@ -577,7 +577,7 @@ sudo systemctl start roma-trading
 docker-compose up -d
 
 # 4. Verify
-curl http://localhost:8000/agents
+curl http://localhost:8080/agents
 ```
 
 ---
@@ -599,7 +599,7 @@ curl http://localhost:8000/agents
 
 ```bash
 # 1. Check backend
-curl http://localhost:8000/agents
+curl http://localhost:8080/agents
 # Should return agent list
 
 # 2. Check frontend
@@ -611,7 +611,7 @@ tail -20 backend/logs/roma_trading_*.log
 # Should show "Loaded N agents"
 
 # 4. Test API
-curl http://localhost:8000/agent/deepseek_aggressive/account
+curl http://localhost:8080/agent/deepseek_aggressive/account
 # Should return account data
 
 # 5. Check decision making

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -178,18 +178,18 @@ analyze_decisions("deepseek-chat-v3.1")
 **Health Check Endpoint**:
 ```bash
 # Simple health check
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 # Expected: {"status":"healthy"}
 
 # With timeout
-curl --max-time 5 http://localhost:8000/health || echo "Backend is down!"
+curl --max-time 5 http://localhost:8080/health || echo "Backend is down!"
 ```
 
 **Monitoring Script** (`monitor.sh`):
 ```bash
 #!/bin/bash
 
-BACKEND_URL="http://localhost:8000"
+BACKEND_URL="http://localhost:8080"
 FRONTEND_URL="http://localhost:3000"
 
 # Check backend
@@ -232,7 +232,7 @@ ps aux | grep "python.*roma_trading" | head -1
 du -sh backend/logs/
 
 # Network connections
-netstat -an | grep :8000
+netstat -an | grep :8080
 ```
 
 ---
@@ -441,7 +441,7 @@ cd backend
 cat backend/logs/decisions/*/decision_*.json | tail -5 | jq '.decisions'
 
 # 3. Check positions
-curl http://localhost:8000/api/agents/deepseek-chat-v3.1/positions
+curl http://localhost:8080/api/agents/deepseek-chat-v3.1/positions
 
 # 4. Close positions manually if needed (via Aster DEX)
 
@@ -558,19 +558,19 @@ echo "🔍 Agent Health Check"
 echo "===================="
 
 # Get agent status
-STATUS=$(curl -s http://localhost:8000/api/agents/$AGENT_ID | jq -r '.is_running')
+STATUS=$(curl -s http://localhost:8080/api/agents/$AGENT_ID | jq -r '.is_running')
 echo "Status: $STATUS"
 
 # Get cycle count
-CYCLES=$(curl -s http://localhost:8000/api/agents/$AGENT_ID | jq -r '.cycle_count')
+CYCLES=$(curl -s http://localhost:8080/api/agents/$AGENT_ID | jq -r '.cycle_count')
 echo "Cycles: $CYCLES"
 
 # Get account
-BALANCE=$(curl -s http://localhost:8000/api/agents/$AGENT_ID/account | jq -r '.total_balance')
+BALANCE=$(curl -s http://localhost:8080/api/agents/$AGENT_ID/account | jq -r '.total_balance')
 echo "Balance: \$$BALANCE"
 
 # Get positions
-POSITIONS=$(curl -s http://localhost:8000/api/agents/$AGENT_ID/positions | jq 'length')
+POSITIONS=$(curl -s http://localhost:8080/api/agents/$AGENT_ID/positions | jq 'length')
 echo "Open Positions: $POSITIONS"
 
 # Check recent errors
@@ -586,7 +586,7 @@ fi
 
 ```bash
 # Quick performance snapshot
-curl -s http://localhost:8000/api/agents/deepseek-chat-v3.1/performance | jq '{
+curl -s http://localhost:8080/api/agents/deepseek-chat-v3.1/performance | jq '{
   win_rate,
   total_pnl,
   profit_factor,

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -95,7 +95,7 @@ system:
 # API Settings
 api:
   host: "0.0.0.0"                 # API server host
-  port: 8000                      # API server port
+  port: 8080                      # API server port
 
 # DEX Accounts
 accounts:

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -116,7 +116,7 @@ ASTER_PRIVATE_KEY_DEEPSEEK=your-private-key
 
 # API Configuration
 API_HOST=0.0.0.0
-API_PORT=8000
+API_PORT=8080
 CORS_ORIGINS=http://localhost:3000
 ```
 
@@ -140,7 +140,7 @@ python -m roma_trading.main
 ============================================================
 🚀 Starting ROMA-01 Trading Platform
 ============================================================
-API Server: http://0.0.0.0:8000
+API Server: http://0.0.0.0:8080
 CORS Origins: http://localhost:3000
 ============================================================
 INFO: Started server process
@@ -165,7 +165,7 @@ npm install
 yarn install
 
 # Create environment file
-echo "NEXT_PUBLIC_API_URL=http://localhost:8000" > .env.local
+echo "NEXT_PUBLIC_API_URL=http://localhost:8080" > .env.local
 
 # Start development server
 npm run dev
@@ -181,8 +181,8 @@ ready - started server on 0.0.0.0:3000, url: http://localhost:3000
 Open your browser:
 
 **Frontend Dashboard**: http://localhost:3000  
-**Backend API**: http://localhost:8000  
-**API Documentation**: http://localhost:8000/docs
+**Backend API**: http://localhost:8080  
+**API Documentation**: http://localhost:8080/docs
 
 You should see:
 - ✅ Agent cards with status
@@ -198,11 +198,11 @@ You should see:
 
 ```bash
 # Health check
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 # Expected: {"status":"healthy"}
 
 # List agents
-curl http://localhost:8000/api/agents
+curl http://localhost:8080/api/agents
 # Expected: JSON array with agent info
 ```
 
@@ -215,7 +215,7 @@ curl http://localhost:8000/api/agents
 
 ### Checklist
 
-- [ ] Backend running on port 8000
+- [ ] Backend running on port 8080
 - [ ] Frontend running on port 3000
 - [ ] Can access dashboard at http://localhost:3000
 - [ ] Agent cards show "RUNNING" status
@@ -255,12 +255,12 @@ python -m roma_trading.main
 
 ### Port Already in Use
 
-**Error**: `Address already in use: 8000`
+**Error**: `Address already in use: 8080`
 
 **Solution**: Kill process or change port
 ```bash
 # Find process
-lsof -i :8000
+lsof -i :8080
 
 # Kill process
 kill -9 <PID>
@@ -276,7 +276,7 @@ API_PORT=8001
 **Solution**: Verify backend is running
 ```bash
 # Test backend
-curl http://localhost:8000/health
+curl http://localhost:8080/health
 
 # If fails, check backend terminal for errors
 ```
@@ -308,7 +308,7 @@ docker-compose down
 
 **Access**:
 - Frontend: http://localhost:3000
-- Backend: http://localhost:8000
+- Backend: http://localhost:8080
 
 ---
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -353,8 +353,8 @@ tail -f logs/roma_trading_*.log
 
 Via API:
 ```bash
-curl http://localhost:8000/agents
-curl http://localhost:8000/agent/deepseek_aggressive/account
+curl http://localhost:8080/agents
+curl http://localhost:8080/agent/deepseek_aggressive/account
 ```
 
 ### Test Single Component
@@ -396,7 +396,7 @@ cd backend
 pkill -f roma_trading
 
 # Method 3: Via API
-curl -X POST http://localhost:8000/stop-all-agents
+curl -X POST http://localhost:8080/stop-all-agents
 ```
 
 ### Close All Positions Manually
@@ -414,10 +414,10 @@ Via Aster DEX UI:
 tail -100 backend/logs/roma_trading_*.log
 
 # Agent status
-curl http://localhost:8000/agents | jq .
+curl http://localhost:8080/agents | jq .
 
 # Account balance
-curl http://localhost:8000/agent/deepseek_aggressive/account | jq .
+curl http://localhost:8080/agent/deepseek_aggressive/account | jq .
 ```
 
 ---

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useLanguage } from "@/store/useLanguage";
 import { getTranslation } from "@/lib/i18n";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 interface CustomPrompts {
   enabled: boolean;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,7 +13,7 @@ import type {
   Trade,
 } from "@/types";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 async function fetcher<T>(url: string): Promise<T> {
   const response = await fetch(`${API_BASE}${url}`);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -182,7 +182,7 @@
 
 "@types/d3-time@*", "@types/d3-time@^3.0.0":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8080eb33edd444e1323f"
   integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
 
 "@types/d3-timer@^3.0.0":
@@ -610,7 +610,7 @@ graceful-fs@^4.2.11:
 
 hasown@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80803"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"


### PR DESCRIPTION
## Summary
- switch the backend default port configuration from 8000 to 8080 across runtime settings and sample configs
- update Docker port mappings and frontend default API base URL to target the new port
- refresh README, Quickstart, deployment, and operations docs so all references point to http://localhost:8080

## Testing
- [ ] not run (start backend or `docker-compose up` and verify http://localhost:8080/health)