### PR TITLE
feat: track net deposits and show adjusted trading returns

### DIFF
--- a/backend/src/roma_trading/agents/trading_agent.py
+++ b/backend/src/roma_trading/agents/trading_agent.py
@@ -104,6 +104,7 @@ class TradingAgent:
         
         # Initialize performance analyzer
         self.performance = PerformanceAnalyzer()
+        self.last_account_snapshot: Dict = {}
 
         # Advanced order configuration
         self.advanced_orders = self.config["strategy"].get("advanced_orders", {})
@@ -295,6 +296,8 @@ class TradingAgent:
                 account=account,
                 positions=positions,
             )
+
+            self.last_account_snapshot = dict(account)
             
             logger.debug(f"🔓 {self.agent_id} released trading lock")
         
@@ -1012,4 +1015,8 @@ Partial close example:
             "model_id": llm_cfg.get("model"),
             "model_provider": llm_cfg.get("provider"),
         }
+
+    def get_account_snapshot(self) -> Dict:
+        """Return the most recent account snapshot with adjustments."""
+        return dict(self.last_account_snapshot) if self.last_account_snapshot else {}
 

--- a/backend/src/roma_trading/api/main.py
+++ b/backend/src/roma_trading/api/main.py
@@ -114,7 +114,11 @@ async def get_account(agent_id: str):
     """Get agent's account balance."""
     try:
         agent = agent_manager.get_agent(agent_id)
-        return await agent.dex.get_account_balance()
+        snapshot = agent.get_account_snapshot()
+        if snapshot:
+            return snapshot
+        account = await agent.dex.get_account_balance()
+        return agent.logger_module.augment_account_balance(account)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/src/roma_trading/core/decision_logger.py
+++ b/backend/src/roma_trading/core/decision_logger.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+
+CASH_FLOW_EPSILON = 1e-6
 from loguru import logger
 
 
@@ -32,14 +34,24 @@ class DecisionLogger:
         # File paths for persistent storage
         self.trades_file = self.log_dir / "trade_history.json"
         self.equity_file = self.log_dir / "equity_history.json"
+        self.cash_flow_file = self.log_dir / "cash_flow_state.json"
         
         # In-memory trade tracking
         self.open_positions: Dict[str, Dict] = {}  # key: "symbol_side"
         self.trade_history: List[Dict] = []
         self.equity_history: List[Dict] = []
+
+        # Runtime state for cash flow tracking
+        self._net_deposits: float = 0.0
+        self._last_equity: Optional[float] = None
+        self._last_unrealized: Optional[float] = None
+        self._last_logged_trade_index: int = 0
+        self._last_external_cash_flow: float = 0.0
         
         # Load existing history from files
         self._load_history()
+        self._load_cash_flow_state()
+        self._initialize_runtime_state()
         
         logger.info(f"Initialized DecisionLogger for agent={agent_id}, loaded {len(self.trade_history)} trades")
 
@@ -63,6 +75,38 @@ class DecisionLogger:
         """
         timestamp = datetime.now()
         filename = f"decision_{timestamp.strftime('%Y%m%d_%H%M%S')}_cycle{cycle}.json"
+
+        current_equity = float(account.get("total_wallet_balance", 0.0))
+        current_unrealized = float(account.get("total_unrealized_profit", 0.0))
+
+        # Calculate realized PnL since last log
+        new_trades = []
+        if self._last_logged_trade_index < len(self.trade_history):
+            new_trades = self.trade_history[self._last_logged_trade_index:]
+        realized_change = sum(t.get("pnl_usdt", 0.0) for t in new_trades)
+
+        equity_delta = 0.0
+        unrealized_delta = 0.0
+        external_cash_flow = 0.0
+        if self._last_equity is not None:
+            equity_delta = current_equity - self._last_equity
+            unrealized_delta = current_unrealized - (self._last_unrealized or 0.0)
+            external_cash_flow = equity_delta - realized_change - unrealized_delta
+            if abs(external_cash_flow) < CASH_FLOW_EPSILON:
+                external_cash_flow = 0.0
+            if external_cash_flow != 0.0:
+                self._net_deposits += external_cash_flow
+                logger.debug(
+                    "Detected external cash flow: %+0.2f USDT (cumulative %+0.2f)",
+                    external_cash_flow,
+                    self._net_deposits,
+                )
+
+        adjusted_equity = current_equity - self._net_deposits
+        account["gross_total_balance"] = current_equity
+        account["adjusted_total_balance"] = adjusted_equity
+        account["net_deposits"] = self._net_deposits
+        account["external_cash_flow"] = external_cash_flow
         
         log_data = {
             "timestamp": timestamp.isoformat(),
@@ -78,15 +122,28 @@ class DecisionLogger:
             json.dump(log_data, f, indent=2)
         
         # Update equity history
-        self.equity_history.append({
+        self._last_equity = current_equity
+        self._last_unrealized = current_unrealized
+        self._last_logged_trade_index = len(self.trade_history)
+        self._last_external_cash_flow = external_cash_flow
+
+        entry = {
             "timestamp": timestamp.isoformat(),
             "cycle": cycle,
-            "equity": account.get("total_wallet_balance", 0.0),
-            "pnl": account.get("total_unrealized_profit", 0.0),
-        })
+            "equity": adjusted_equity,
+            "adjusted_equity": adjusted_equity,
+            "gross_equity": current_equity,
+            "unrealized_pnl": current_unrealized,
+            "pnl": current_unrealized,
+            "net_deposits": self._net_deposits,
+            "external_cash_flow": external_cash_flow,
+        }
+
+        self.equity_history.append(entry)
         
         # Save equity history to file
         self._save_equity_history()
+        self._save_cash_flow_state()
         
         logger.info(f"Logged decision cycle {cycle} for agent {self.agent_id}")
 
@@ -227,9 +284,8 @@ class DecisionLogger:
 
     def get_equity_history(self, limit: Optional[int] = None) -> List[Dict]:
         """Get equity history."""
-        if limit:
-            return self.equity_history[-limit:]
-        return self.equity_history
+        history = self.equity_history[-limit:] if limit else self.equity_history
+        return [self._ensure_equity_entry_fields(entry) for entry in history]
 
     def get_trade_history(self, limit: Optional[int] = None) -> List[Dict]:
         """Get completed trade history."""
@@ -255,6 +311,7 @@ class DecisionLogger:
                 with open(self.equity_file, "r") as f:
                     self.equity_history = json.load(f)
                 logger.info(f"Loaded {len(self.equity_history)} equity points from {self.equity_file}")
+                self.equity_history = [self._ensure_equity_entry_fields(entry) for entry in self.equity_history]
             except Exception as e:
                 logger.warning(f"Failed to load equity history: {e}")
                 self.equity_history = []
@@ -276,4 +333,86 @@ class DecisionLogger:
             logger.debug(f"Saved {len(self.equity_history)} equity points to {self.equity_file}")
         except Exception as e:
             logger.error(f"Failed to save equity history: {e}")
+
+    def _load_cash_flow_state(self) -> None:
+        """Load cash flow tracking state from disk."""
+        if not self.cash_flow_file.exists():
+            return
+        try:
+            with open(self.cash_flow_file, "r") as f:
+                data = json.load(f)
+            self._net_deposits = float(data.get("net_deposits", 0.0))
+            self._last_equity = data.get("last_equity")
+            self._last_unrealized = data.get("last_unrealized")
+            self._last_external_cash_flow = data.get("last_external_cash_flow", 0.0)
+        except Exception as e:
+            logger.warning(f"Failed to load cash flow state: {e}")
+
+    def _initialize_runtime_state(self) -> None:
+        """Initialize runtime state from loaded history."""
+        self._last_logged_trade_index = len(self.trade_history)
+
+        if self.equity_history:
+            last_entry = self.equity_history[-1]
+            if self._last_equity is None:
+                self._last_equity = last_entry.get("equity")
+            if self._last_unrealized is None:
+                self._last_unrealized = last_entry.get("unrealized_pnl", last_entry.get("pnl", 0.0))
+            # Prefer persisted net deposits if available; otherwise derive from entry
+            if "net_deposits" in last_entry:
+                self._net_deposits = last_entry.get("net_deposits", self._net_deposits)
+            if "external_cash_flow" in last_entry:
+                self._last_external_cash_flow = last_entry.get("external_cash_flow", 0.0)
+
+    def _save_cash_flow_state(self) -> None:
+        """Persist cash flow tracking state to disk."""
+        try:
+            data = {
+                "net_deposits": self._net_deposits,
+                "last_equity": self._last_equity,
+                "last_unrealized": self._last_unrealized,
+                "last_external_cash_flow": self._last_external_cash_flow,
+            }
+            with open(self.cash_flow_file, "w") as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            logger.warning(f"Failed to save cash flow state: {e}")
+
+    def _ensure_equity_entry_fields(self, entry: Dict) -> Dict:
+        """Ensure legacy equity entries contain expected fields."""
+        normalized = dict(entry)
+        if "unrealized_pnl" not in normalized:
+            normalized["unrealized_pnl"] = normalized.get("pnl", 0.0)
+        if "pnl" not in normalized:
+            normalized["pnl"] = normalized.get("unrealized_pnl", 0.0)
+        if "net_deposits" not in normalized:
+            normalized["net_deposits"] = 0.0
+        if "external_cash_flow" not in normalized:
+            normalized["external_cash_flow"] = 0.0
+        if "gross_equity" not in normalized:
+            normalized["gross_equity"] = normalized.get("equity", 0.0)
+        if "adjusted_equity" not in normalized:
+            normalized["adjusted_equity"] = normalized.get("equity", 0.0) - normalized.get("net_deposits", 0.0)
+        normalized["equity"] = normalized.get("adjusted_equity", normalized.get("equity", 0.0))
+        return normalized
+
+    def get_net_deposits(self) -> float:
+        """Return cumulative net deposits (deposits minus withdrawals)."""
+        return self._net_deposits
+
+    def get_last_external_cash_flow(self) -> float:
+        """Return the most recent cycle's detected external cash flow."""
+        return self._last_external_cash_flow
+
+    def augment_account_balance(self, account: Dict) -> Dict:
+        """Augment raw account balance with deposit-adjusted metrics."""
+        enriched = dict(account)
+        current_equity = float(enriched.get("total_wallet_balance", 0.0))
+        adjusted_equity = current_equity - self._net_deposits
+        enriched.setdefault("total_unrealized_profit", float(enriched.get("total_unrealized_profit", 0.0)))
+        enriched["adjusted_total_balance"] = adjusted_equity
+        enriched["gross_total_balance"] = current_equity
+        enriched["net_deposits"] = self._net_deposits
+        enriched.setdefault("external_cash_flow", 0.0)
+        return enriched
 

--- a/frontend/src/components/leaderboard/LeaderboardOverview.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardOverview.tsx
@@ -75,8 +75,9 @@ export default function LeaderboardOverview() {
     let winner: typeof agents[0] | null = null;
     
     allAccountsData.forEach(({ agentId, data }) => {
-      if (data?.total_wallet_balance && data.total_wallet_balance > maxEquity) {
-        maxEquity = data.total_wallet_balance;
+      const equityValue = data?.adjusted_total_balance ?? data?.total_wallet_balance;
+      if (equityValue && equityValue > maxEquity) {
+        maxEquity = equityValue;
         winner = agents.find(a => a.id === agentId) || null;
       }
     });
@@ -165,7 +166,9 @@ function WinnerCard({ agent, symbols }: { agent: any; symbols: string[] }) {
   );
 
   const color = agent ? getModelColor(agent.id) : undefined;
-  const equity = account?.total_wallet_balance || 0;
+  const equityRaw = account?.gross_total_balance ?? account?.total_wallet_balance ?? 0;
+  const equityAdjusted = account?.adjusted_total_balance ?? equityRaw;
+  const netDeposits = account?.net_deposits ?? 0;
 
   return (
     <div
@@ -199,7 +202,17 @@ function WinnerCard({ agent, symbols }: { agent: any; symbols: string[] }) {
               TOTAL EQUITY
             </div>
             <div className="text-xl font-bold tabular-nums" style={{ color: "var(--foreground)" }}>
-              {fmtUSD(equity)}
+              {fmtUSD(equityRaw)}
+            </div>
+            <div className="mt-2 grid gap-1 text-xs" style={{ color: "var(--muted-text)" }}>
+              <div className="flex items-center justify-between">
+                <span>Net Deposits</span>
+                <span style={{ color: "var(--foreground)" }}>{fmtUSD(netDeposits)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Deposit-Adjusted Equity</span>
+                <span style={{ color: "var(--foreground)" }}>{fmtUSD(equityAdjusted)}</span>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -108,10 +108,14 @@ function LeaderboardRow({
     );
   }
 
-  // Use first equity history point as initial balance, fallback to 10000 if no history
-  const initialBalance = equityHistory.length > 0 ? equityHistory[0].equity : 10000;
-  const equity = account.total_wallet_balance;
-  const totalPnl = equity - initialBalance;
+  const equityAdjusted = account.adjusted_total_balance ?? account.total_wallet_balance ?? 0;
+  // Use first equity history point as initial balance, fallback to adjusted equity or 10000
+  const initialPoint = equityHistory.length > 0 ? equityHistory[0] : null;
+  const initialBalance = initialPoint
+    ? initialPoint.adjusted_equity ?? initialPoint.equity
+    : equityAdjusted || 10000;
+  const equityDisplay = account.gross_total_balance ?? account.total_wallet_balance ?? equityAdjusted;
+  const totalPnl = equityAdjusted - initialBalance;
   const returnPct = initialBalance > 0 ? (totalPnl / initialBalance) * 100 : 0;
   const sharpe = returnPct > 0 ? returnPct / 100 : returnPct / 50;
 
@@ -153,7 +157,7 @@ function LeaderboardRow({
         </Link>
       </td>
       <td className="py-1.5 pr-2 tabular-nums font-semibold" style={{ color: "var(--brand-accent)" }}>
-        {fmtUSD(equity)}
+        {fmtUSD(equityDisplay)}
       </td>
       {mode === "advanced" ? (
         <>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -32,6 +32,10 @@ export interface Account {
   total_wallet_balance: number;
   available_balance: number;
   total_unrealized_profit: number;
+  adjusted_total_balance?: number;
+  gross_total_balance?: number;
+  net_deposits?: number;
+  external_cash_flow?: number;
 }
 
 export interface Position {
@@ -87,7 +91,12 @@ export interface EquityPoint {
   timestamp: string;
   cycle: number;
   equity: number;
+  adjusted_equity?: number;
+  gross_equity?: number;
   pnl: number;
+  unrealized_pnl?: number;
+  net_deposits?: number;
+  external_cash_flow?: number;
 }
 
 export interface Trade {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -182,7 +182,7 @@
 
 "@types/d3-time@*", "@types/d3-time@^3.0.0":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8080eb33edd444e1323f"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
   integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
 
 "@types/d3-timer@^3.0.0":
@@ -278,9 +278,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 baseline-browser-mapping@^2.8.19:
-  version "2.8.21"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.21.tgz#2f9cccde871bfa4aec9dbf92d0ee746e4f1892e4"
-  integrity sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==
+  version "2.8.25"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz#947dc6f81778e0fa0424a2ab9ea09a3033e71109"
+  integrity sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -325,9 +325,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001751:
-  version "1.0.30001752"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001752.tgz#afa28d0830709507162bc6ed3f7cb23b00926a99"
-  integrity sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==
+  version "1.0.30001754"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz#7758299d9a72cce4e6b038788a15b12b44002759"
+  integrity sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==
 
 chokidar@^3.6.0:
   version "3.6.0"
@@ -500,9 +500,9 @@ eastasianwidth@^0.2.0:
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 electron-to-chromium@^1.5.238:
-  version "1.5.244"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz#b9b61e3d24ef4203489951468614f2a360763820"
-  integrity sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==
+  version "1.5.249"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.249.tgz#e4fc3a3e60bb347361e4e876bb31903a9132a447"
+  integrity sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -610,7 +610,7 @@ graceful-fs@^4.2.11:
 
 hasown@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80803"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
@@ -1057,7 +1057,6 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1076,7 +1075,6 @@ string-width@^5.0.1, string-width@^5.1.2:
     strip-ansi "^7.0.1"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## Summary
- detect external deposits/withdrawals in the backend decision logger and persist a cumulative net_deposits balance
- expose deposit-adjusted account snapshots via the agent API so frontend metrics aren’t inflated by cash movements
- surface both gross equity and deposit-adjusted values in the dashboard (leaderboard, winner card, account value chart) while keeping % returns based on adjusted equity

## Testing
- [x] run (restart agents and verify adjusted equity/net deposits in UI & /api/agents/{id}/account)