### PR TITLE
feat: Add bilingual system prompts for trading decisions

### DIFF
--- a/backend/config/README.md
+++ b/backend/config/README.md
@@ -1,5 +1,7 @@
 # ROMA-01 Trading Configuration Guide
 
+**语言选择 / Language:** [English](README.md) · [中文](README.zh-CN.md)
+
 This directory contains configuration files for the ROMA-01 trading platform.
 
 ## ⚠️ Configuration Update
@@ -47,6 +49,7 @@ This file controls system-wide settings that apply to all trading agents.
 | `system.scan_interval_minutes` | Integer | How often each agent scans the market and makes decisions (in minutes) | 3 |
 | `system.max_concurrent_agents` | Integer | Maximum number of agents that can run simultaneously | 6 |
 | `system.log_level` | String | Logging level (DEBUG, INFO, WARNING, ERROR) | INFO |
+| `system.prompt_language` | String | Default language for system prompts (`en` or `zh`) | en |
 
 ### API Settings
 

--- a/backend/config/README.zh-CN.md
+++ b/backend/config/README.zh-CN.md
@@ -1,0 +1,73 @@
+ # ROMA-01 交易平台配置概览（中文）
+
+ 该目录包含 ROMA-01 交易平台的配置文件。
+
+ ## ⚠️ 配置更新
+
+ **平台现已采用“账户中心化配置”**——所有配置集中存放在 `trading_config.yaml` 中。  
+ 详细说明请参阅 **[README_CONFIG.zh-CN.md](README_CONFIG.zh-CN.md)**。
+
+ ## 快速开始
+
+ 1. 编辑 `trading_config.yaml`，填写账户 / 模型 / 智能体信息  
+ 2. 在 `.env` 文件中设置环境变量  
+ 3. 启动平台
+
+ 更详细的操作指南请参考 **[QUICK_START.md](QUICK_START.md)**。
+
+ ## 目录结构
+
+ ```
+ config/
+ ├── README.md / README.zh-CN.md              # 当前文件（英文 / 中文，保留旧文档）
+ ├── README_CONFIG.md / README_CONFIG.zh-CN.md# 新版配置指南（推荐）
+ ├── QUICK_START.md                           # 快速入门指南
+ └── trading_config.yaml                      # 主配置文件（账户中心化）
+ ```
+
+ ## ⚠️ 旧版文档说明
+
+ 下方内容为**旧配置格式**的文档，仅供历史参考。  
+ **新部署请使用账户中心化配置**，详见 `README_CONFIG.zh-CN.md`。
+
+ ---
+
+ ## 旧版：全局配置 (`trading_config.yaml`)
+
+ > **说明：** 以下参数仅针对旧格式。新版配置将账户 / 模型 / 智能体拆分管理。
+
+ ### 系统设置
+
+ | 参数 | 类型 | 说明 | 默认值 |
+ |------|------|------|--------|
+ | `system.scan_interval_minutes` | Integer | 智能体轮询市场并决策的间隔（分钟） | 3 |
+ | `system.max_concurrent_agents` | Integer | 同时运行的智能体数量上限 | 6 |
+ | `system.log_level` | String | 日志等级（DEBUG / INFO / WARNING / ERROR） | INFO |
+ | `system.prompt_language` | String | 系统提示词语言（`en` 或 `zh`） | en |
+
+ ### API 设置
+
+ | 参数 | 类型 | 说明 | 默认值 |
+ |------|------|------|--------|
+ | `api.host` | String | API 服务监听地址 | 0.0.0.0 |
+ | `api.port` | Integer | API 服务端口 | 8080 |
+
+ ### 智能体配置
+
+ `agents` 数组定义需要启用的智能体：
+
+ | 参数 | 类型 | 说明 | 必填 |
+ |------|------|------|------|
+ | `id` | String | 智能体唯一标识 | 是 |
+ | `name` | String | 展示名称 | 是 |
+ | `enabled` | Boolean | 是否启用该智能体 | 是 |
+ | `config_file` | String | 对应模型配置文件路径 | 是 |
+
+ ## 模型配置（旧版）
+
+ 每个模型在 `models/` 目录下有独立 YAML 文件，用于控制该智能体的行为。
+
+ ---
+
+ *更多详细内容与风险参数说明请参考英文原文。建议迁移到账户中心化配置，避免重复维护多份文件。*
+

--- a/backend/config/README_CONFIG.md
+++ b/backend/config/README_CONFIG.md
@@ -1,5 +1,7 @@
 # ROMA Trading Platform - Configuration Guide
 
+**Language / 语言选择:** [English](README_CONFIG.md) · [中文](README_CONFIG.zh-CN.md)
+
 ## Quick Start
 
 **New users**: Start by editing the default configuration:
@@ -274,6 +276,7 @@ agents:
 | `initial_balance` | Float | Starting balance for performance tracking (USDT). Used for calculations and display, not actual account balance. | `10000.0` | Match your actual balance |
 | `scan_interval_minutes` | Integer | How often the agent scans the market and makes trading decisions (in minutes). | `3` | 3-5 minutes |
 | `max_account_usage_pct` | Integer | Maximum percentage of account balance to use for trading. Useful when multiple agents share one account. | `100` | 100% for single agent, 60-80% per agent if sharing |
+| `prompt_language` | String | System prompt language (`en` or `zh`). Determines AI decision language. | Inherits `system.prompt_language` | Match your operating language |
 
 #### Trading Pairs
 

--- a/backend/config/README_CONFIG.zh-CN.md
+++ b/backend/config/README_CONFIG.zh-CN.md
@@ -1,0 +1,203 @@
+# ROMA 交易平台配置指南（中文）
+
+> 英文版请参阅 `README_CONFIG.md`。本文提供账户中心化配置的完整中文说明。
+
+## 快速开始
+
+```bash
+cd backend/config
+# 编辑 trading_config.yaml，填写账户 / 模型 / 智能体信息
+vim trading_config.yaml   # 或使用你偏好的编辑器
+```
+
+详细操作步骤参考 `QUICK_START.md`。
+
+## 配置概览
+
+ROMA 平台支持两种配置风格：
+
+1. **旧版（Legacy）**：每个智能体单独一个配置文件  
+2. **账户中心化（推荐）**：统一在 `trading_config.yaml` 中维护账户 / 模型 / 智能体
+
+核心文件：
+
+- `trading_config.yaml`：主配置文件  
+- `README_CONFIG.md / README_CONFIG.zh-CN.md`：详细文档  
+- `QUICK_START.md`：快速上手指导
+
+---
+
+## 账户中心化配置结构
+
+```yaml
+accounts:
+  - id: "aster-acc-01"
+    dex_type: "aster"
+    user: ${ASTER_USER_01}
+    signer: ${ASTER_SIGNER_01}
+    private_key: ${ASTER_PRIVATE_KEY_01}
+    testnet: false
+    hedge_mode: false
+
+models:
+  - id: "deepseek-v3.1"
+    provider: "deepseek"
+    api_key: ${DEEPSEEK_API_KEY}
+    model: "deepseek-chat"
+    temperature: 0.15
+    max_tokens: 4000
+
+agents:
+  - id: "deepseek-aster-01"
+    name: "DeepSeek on Aster-01"
+    enabled: true
+    account_id: "aster-acc-01"
+    model_id: "deepseek-v3.1"
+    strategy:
+      initial_balance: 10000.0
+      prompt_language: "en"  # 可选：覆盖系统默认语言
+      scan_interval_minutes: 3
+      max_account_usage_pct: 100
+      default_coins:
+        - BTCUSDT
+        - ETHUSDT
+      risk_management:
+        max_positions: 3
+        max_leverage: 10
+        max_position_size_pct: 30
+        max_total_position_pct: 80
+        max_single_trade_pct: 50
+        max_single_trade_with_positions_pct: 30
+        max_daily_loss_pct: 15
+        stop_loss_pct: 3
+        take_profit_pct: 10
+      trading_style: "balanced"
+      custom_prompts:
+        enabled: false
+```
+
+### 关键字段说明
+
+#### 系统设置（`system`）
+
+| 字段 | 说明 | 默认值 |
+|------|------|--------|
+| `scan_interval_minutes` | 智能体扫描市场的间隔（分钟） | 3 |
+| `max_concurrent_agents` | 并发运行的智能体数量上限 | 6 |
+| `log_level` | 日志等级（DEBUG / INFO / WARNING / ERROR） | INFO |
+| `prompt_language` | 系统提示词语言（`en` 或 `zh`） | en |
+
+#### 策略基础设置
+
+| 字段 | 说明 | 默认值 |
+|------|------|--------|
+| `initial_balance` | 性能统计使用的初始资金（USDT） | 10000.0 |
+| `scan_interval_minutes` | 特定智能体扫描频率 | 3 |
+| `max_account_usage_pct` | 单个智能体允许占用的账户资金比例 | 100 |
+| `prompt_language` | 覆盖系统级提示词语言（可选） | 继承系统设置 |
+| `trading_style` | 交易风格：`conservative` / `balanced` / `aggressive` | balanced |
+
+#### 交易品种
+
+```yaml
+default_coins:
+  - BTCUSDT
+  - ETHUSDT
+  - SOLUSDT
+  - BNBUSDT
+  - DOGEUSDT
+  - XRPUSDT
+```
+
+> 所有品种需以 `USDT` 结尾，实际可交易品种取决于所接入的交易所。
+
+#### 风险管理字段
+
+| 字段 | 说明 | 建议范围 |
+|------|------|----------|
+| `max_positions` | 同时持仓数量上限 | 2-5 |
+| `max_leverage` | 最大杠杆倍率 | 5-10 |
+| `max_position_size_pct` | 单笔仓位占账户资金比例上限 | 20-35 |
+| `max_total_position_pct` | 所有仓位合计占比 | 70-85 |
+| `max_single_trade_pct` | 无持仓时的单笔开仓占比 | 40-60 |
+| `max_single_trade_with_positions_pct` | 有持仓时的单笔开仓占比 | 25-35 |
+| `max_daily_loss_pct` | 单日最大亏损百分比（触发后停止交易） | 10-20 |
+| `stop_loss_pct` / `take_profit_pct` | 止损 / 止盈比例 | 2-5 / 8-15 |
+
+#### 自定义提示词
+
+```yaml
+custom_prompts:
+  enabled: true
+  trading_philosophy: "强调顺势而为，控制回撤"
+  entry_preferences: "仅在EMA20上方并伴随放量时做多"
+  position_management: "盈利达到2R时减仓，移动止损至保本"
+  market_preferences: "避开重大数据公布前30分钟"
+  additional_rules: "若出现多空信号冲突则选择观望"
+```
+
+开启后自定义内容会附加到系统提示词末尾，与原有风险规则叠加使用。
+
+---
+
+## 环境变量
+
+将敏感凭证写入 `.env` / 系统环境变量，配置文件中引用变量名：
+
+```bash
+# LLM 密钥
+DEEPSEEK_API_KEY=xxx
+QWEN_API_KEY=xxx
+ANTHROPIC_API_KEY=xxx
+XAI_API_KEY=xxx
+GOOGLE_API_KEY=xxx
+OPENAI_API_KEY=xxx
+
+# Aster 账户
+ASTER_USER_01=0x...
+ASTER_SIGNER_01=0x...
+ASTER_PRIVATE_KEY_01=...
+
+# Hyperliquid 账户
+HL_SECRET_KEY_01=...
+HL_ACCOUNT_ADDRESS_01=0x...
+```
+
+---
+
+## 迁移建议
+
+1. **抽取账户**：将旧配置中的交易账户信息搬到 `accounts` 段落  
+2. **抽取模型**：将 LLM 设置迁至 `models` 段落  
+3. **创建智能体**：在 `agents` 中引用账户和模型，并复制策略参数  
+4. **启用提示词语言**：在系统或策略级别设置 `prompt_language: "zh"`，即可启用中文提示词与决策输出
+
+---
+
+## 最佳实践
+
+1. **一账户一智能体（生产环境）**：避免订单冲突  
+2. **复用模型**：同一模型可被多个智能体引用  
+3. **使用环境变量**：不要在配置文件中硬编码密钥  
+4. **先上测试网**：`testnet: true` 先行验证策略  
+5. **定期回顾风险参数**：根据市场波动调整杠杆、止损等指标  
+6. **关注日志语言**：切换 `prompt_language` 后查看日志，确认决策文字符合预期语言
+
+---
+
+## 常见问题
+
+- **“Account not found”**：确认 `account_id` 是否在 `accounts` 段落中定义  
+- **“Model not found”**：确认 `model_id` 是否在 `models` 段落中存在  
+- **未下单**：检查 `max_daily_loss_pct` 是否触发，或者风险参数是否过于保守  
+- **提示词语言未切换**：确保系统级或策略级 `prompt_language` 已设置为 `zh`，同时重启后端或等待下一轮交易周期
+
+---
+
+如需更多帮助，请查阅：
+
+- `/backend/ACCOUNT_SETUP.md`：交易所账户配置  
+- `/README.md` 与 `/README.zh-CN.md`：平台总览  
+- `/docs/` 目录：部署、运维、API 等专题文档
+
+

--- a/backend/config/trading_config.yaml
+++ b/backend/config/trading_config.yaml
@@ -13,6 +13,7 @@ system:
   scan_interval_minutes: 3
   max_concurrent_agents: 6
   log_level: "INFO"
+  prompt_language: "en" # zh(中文) or en(English)
 
 api:
   host: "0.0.0.0"

--- a/backend/config/trading_config.yaml.example
+++ b/backend/config/trading_config.yaml.example
@@ -13,6 +13,7 @@ system:
   scan_interval_minutes: 3
   max_concurrent_agents: 6
   log_level: "INFO"
+  prompt_language: "en" # zh（中文） or en(English)
 
 api:
   host: "0.0.0.0"

--- a/backend/src/roma_trading/agents/agent_manager.py
+++ b/backend/src/roma_trading/agents/agent_manager.py
@@ -172,6 +172,7 @@ class AgentManager:
                 "initial_balance": 10000.0,
                 "scan_interval_minutes": main_config.get("system", {}).get("scan_interval_minutes", 3),
                 "max_account_usage_pct": 100,
+                "prompt_language": main_config.get("system", {}).get("prompt_language", "en"),
                 "default_coins": ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "DOGEUSDT", "XRPUSDT"],
                 "risk_management": {
                     "max_positions": 3,

--- a/backend/src/roma_trading/api/main.py
+++ b/backend/src/roma_trading/api/main.py
@@ -17,7 +17,7 @@ Endpoints:
 
 import asyncio
 from typing import Optional
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from contextlib import asynccontextmanager
@@ -389,7 +389,7 @@ async def get_custom_prompts(agent_id: str):
 
 
 @app.get("/api/agents/{agent_id}/prompts/preview")
-async def get_full_prompt_preview(agent_id: str):
+async def get_full_prompt_preview(agent_id: str, language: Optional[str] = Query(None)):
     """
     Get the complete system prompt that will be sent to AI
     
@@ -403,7 +403,7 @@ async def get_full_prompt_preview(agent_id: str):
         agent = agent_manager.get_agent(agent_id)
         
         # Build the actual system prompt using agent's method
-        full_prompt = agent._build_system_prompt()
+        full_prompt = agent._build_system_prompt(language=language)
         
         return {
             "status": "success",

--- a/backend/src/roma_trading/core/performance.py
+++ b/backend/src/roma_trading/core/performance.py
@@ -159,26 +159,43 @@ class PerformanceAnalyzer:
         }
 
     @staticmethod
-    def format_performance(metrics: Dict) -> str:
+    def format_performance(metrics: Dict, language: str = "en") -> str:
         """Format performance metrics for AI prompt."""
         if metrics["total_trades"] == 0:
-            return "No trades yet."
+            return "No trades yet." if language != "zh" else "暂无交易记录。"
         
-        lines = [
-            f"**Performance Summary ({metrics['total_trades']} trades)**",
-            f"Win Rate: {metrics['win_rate']:.1f}% ({metrics['wins']}W / {metrics['losses']}L)",
-            f"Avg Profit: ${metrics['avg_profit']:.2f} | Avg Loss: ${metrics['avg_loss']:.2f}",
-            f"Profit Factor: {metrics['profit_factor']:.2f}",
-            f"Sharpe Ratio: {metrics['sharpe_ratio']:.2f}",
-            f"Max Drawdown: {metrics['max_drawdown']:.2f}%",
-            f"Total P/L: ${metrics['total_pnl']:+.2f}",
-        ]
-        
-        if metrics["best_trade"]:
-            lines.append(f"Best: {metrics['best_trade']['symbol']} ${metrics['best_trade']['pnl']:+.2f}")
-        
-        if metrics["worst_trade"]:
-            lines.append(f"Worst: {metrics['worst_trade']['symbol']} ${metrics['worst_trade']['pnl']:+.2f}")
+        if language == "zh":
+            lines = [
+                f"**绩效概览（{metrics['total_trades']} 笔交易）**",
+                f"胜率：{metrics['win_rate']:.1f}%（{metrics['wins']} 胜 / {metrics['losses']} 负）",
+                f"平均盈利：${metrics['avg_profit']:.2f} | 平均亏损：${metrics['avg_loss']:.2f}",
+                f"收益因子：{metrics['profit_factor']:.2f}",
+                f"夏普比率：{metrics['sharpe_ratio']:.2f}",
+                f"最大回撤：{metrics['max_drawdown']:.2f}%",
+                f"总盈亏：${metrics['total_pnl']:+.2f}",
+            ]
+            
+            if metrics["best_trade"]:
+                lines.append(f"最佳交易：{metrics['best_trade']['symbol']} ${metrics['best_trade']['pnl']:+.2f}")
+            
+            if metrics["worst_trade"]:
+                lines.append(f"最差交易：{metrics['worst_trade']['symbol']} ${metrics['worst_trade']['pnl']:+.2f}")
+        else:
+            lines = [
+                f"**Performance Summary ({metrics['total_trades']} trades)**",
+                f"Win Rate: {metrics['win_rate']:.1f}% ({metrics['wins']}W / {metrics['losses']}L)",
+                f"Avg Profit: ${metrics['avg_profit']:.2f} | Avg Loss: ${metrics['avg_loss']:.2f}",
+                f"Profit Factor: {metrics['profit_factor']:.2f}",
+                f"Sharpe Ratio: {metrics['sharpe_ratio']:.2f}",
+                f"Max Drawdown: {metrics['max_drawdown']:.2f}%",
+                f"Total P/L: ${metrics['total_pnl']:+.2f}",
+            ]
+            
+            if metrics["best_trade"]:
+                lines.append(f"Best: {metrics['best_trade']['symbol']} ${metrics['best_trade']['pnl']:+.2f}")
+            
+            if metrics["worst_trade"]:
+                lines.append(f"Worst: {metrics['worst_trade']['symbol']} ${metrics['worst_trade']['pnl']:+.2f}")
         
         return "\n".join(lines)
 

--- a/backend/src/roma_trading/toolkits/technical_analysis.py
+++ b/backend/src/roma_trading/toolkits/technical_analysis.py
@@ -176,7 +176,13 @@ class TechnicalAnalysisToolkit:
         }
 
     @classmethod
-    def format_market_data(cls, symbol: str, data_3m: Dict, data_4h: Optional[Dict] = None) -> str:
+    def format_market_data(
+        cls,
+        symbol: str,
+        data_3m: Dict,
+        data_4h: Optional[Dict] = None,
+        language: str = "en",
+    ) -> str:
         """
         Format market data for AI prompt.
         
@@ -189,23 +195,43 @@ class TechnicalAnalysisToolkit:
             Formatted string for AI consumption
         """
         lines = [f"**{symbol}**"]
-        lines.append(f"Price: ${data_3m['current_price']:.4f}")
         
-        if data_3m['price_change_1h'] != 0:
-            lines.append(f"1h: {data_3m['price_change_1h']:+.2f}%")
-        
-        lines.append(f"RSI(7): {data_3m['rsi']:.1f}")
-        lines.append(f"MACD: {data_3m['macd']['macd']:.4f}")
-        lines.append(f"EMA20: ${data_3m['ema20']:.4f}")
-        
-        if data_3m['volume_ratio'] > 1.5:
-            lines.append(f"Volume: {data_3m['volume_ratio']:.1f}x avg ⬆")
-        
-        if data_4h:
-            lines.append(f"\n4h Trend: {data_4h['price_change_4h']:+.2f}%")
-            lines.append(f"RSI(14): {data_4h['rsi']:.1f}")
-            if data_4h.get('ema50'):
-                lines.append(f"EMA50: ${data_4h['ema50']:.4f}")
+        if language == "zh":
+            lines.append(f"价格：${data_3m['current_price']:.4f}")
+            
+            if data_3m['price_change_1h'] != 0:
+                lines.append(f"1 小时涨跌：{data_3m['price_change_1h']:+.2f}%")
+            
+            lines.append(f"RSI(7)：{data_3m['rsi']:.1f}")
+            lines.append(f"MACD：{data_3m['macd']['macd']:.4f}")
+            lines.append(f"EMA20：${data_3m['ema20']:.4f}")
+            
+            if data_3m['volume_ratio'] > 1.5:
+                lines.append(f"成交量：{data_3m['volume_ratio']:.1f} 倍均量 ⬆")
+            
+            if data_4h:
+                lines.append(f"\n4 小时趋势：{data_4h['price_change_4h']:+.2f}%")
+                lines.append(f"RSI(14)：{data_4h['rsi']:.1f}")
+                if data_4h.get('ema50'):
+                    lines.append(f"EMA50：${data_4h['ema50']:.4f}")
+        else:
+            lines.append(f"Price: ${data_3m['current_price']:.4f}")
+            
+            if data_3m['price_change_1h'] != 0:
+                lines.append(f"1h: {data_3m['price_change_1h']:+.2f}%")
+            
+            lines.append(f"RSI(7): {data_3m['rsi']:.1f}")
+            lines.append(f"MACD: {data_3m['macd']['macd']:.4f}")
+            lines.append(f"EMA20: ${data_3m['ema20']:.4f}")
+            
+            if data_3m['volume_ratio'] > 1.5:
+                lines.append(f"Volume: {data_3m['volume_ratio']:.1f}x avg ⬆")
+            
+            if data_4h:
+                lines.append(f"\n4h Trend: {data_4h['price_change_4h']:+.2f}%")
+                lines.append(f"RSI(14): {data_4h['rsi']:.1f}")
+                if data_4h.get('ema50'):
+                    lines.append(f"EMA50: ${data_4h['ema50']:.4f}")
         
         return "\n".join(lines)
 

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useLanguage } from "@/store/useLanguage";
 import { getTranslation } from "@/lib/i18n";
+import { api } from "@/lib/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
@@ -132,14 +133,8 @@ export default function PromptEditor({ agentId }: { agentId: string }) {
     setLoadingPreview(true);
     setError(null);
     try {
-      const response = await fetch(`${API_BASE}/api/agents/${agentId}/prompts/preview`);
-      const data = await response.json();
-      if (data.status === "success") {
-        setFullPrompt(data.data.full_prompt);
-      } else {
-        setFullPrompt("Failed to load preview");
-        setError("Failed to load preview");
-      }
+      const preview = await api.getFullPromptPreview(agentId, language);
+      setFullPrompt(preview);
     } catch (err) {
       console.error("Failed to load prompt preview:", err);
       setFullPrompt("Failed to load preview");
@@ -155,6 +150,13 @@ export default function PromptEditor({ agentId }: { agentId: string }) {
     }
     setShowPreview(!showPreview);
   };
+
+  useEffect(() => {
+    if (showPreview) {
+      loadFullPromptPreview();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language]);
 
   if (loading) {
     return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -104,8 +104,12 @@ export const api = {
   },
   
   // Get full prompt preview (core rules + custom prompts)
-  getFullPromptPreview: async (agentId: string): Promise<string> => {
-    const response = await fetch(`${API_BASE}/api/agents/${agentId}/prompts/preview`);
+  getFullPromptPreview: async (agentId: string, language?: string): Promise<string> => {
+    const url = new URL(`${API_BASE}/api/agents/${agentId}/prompts/preview`);
+    if (language) {
+      url.searchParams.set("language", language);
+    }
+    const response = await fetch(url.toString());
     const data = await response.json();
     if (data.status === "success") {
       return data.data.full_prompt;


### PR DESCRIPTION
## Summary
- add `prompt_language` configuration (defaulting from system settings) so each agent builds its system prompt in Chinese or English
- localize the core trading prompt, performance summary, and market context formatting to output either zh or en text
- update `/api/agents/{id}/prompts/preview` plus the frontend prompt editor to request previews in the active UI language

## Testing
- [x] run (switch `prompt_language` between `zh`/`en`, reload prompt preview, and verify agent decisions/logs reflect the selected language)